### PR TITLE
Adding Eucalyptus support

### DIFF
--- a/ami_creator/ami_creator.py
+++ b/ami_creator/ami_creator.py
@@ -75,8 +75,9 @@ class AmiCreator(imgcreate.LoopImageCreator):
         imgcreate.LoopImageCreator.__init__(self, *args, **kwargs)
 
         # amis need xenblk at least
-        self.__modules = ["xenblk", "xen_blkfront", "virtio_net", 
-                          "virtio_blk", "virtio_balloon", "e1000"]
+        self.__modules = ["xenblk", "xen_blkfront", "virtio_net", "virtio_pci",
+                          "virtio_blk", "virtio_balloon", "e1000", 
+                          "scsi_transport_sas", "mptbase", "mptscsih", "mptsas"]
         self.__modules.extend(imgcreate.kickstart.get_modules(self.ks))
 
     def _get_disk_type(self):

--- a/ami_creator/ami_creator.py
+++ b/ami_creator/ami_creator.py
@@ -78,7 +78,7 @@ class AmiCreator(imgcreate.LoopImageCreator):
         self.__modules = ["xenblk", "xen_blkfront", "virtio_net", "virtio_pci",
                           "virtio_blk", "virtio_balloon", "e1000", "sym53c8xx",
                           "scsi_transport_sas", "mptbase", "mptscsih",
-                          "sd_mod", "mptsas", "sg" ]
+                          "sd_mod", "mptsas", "sg", "acpiphp" ]
         self.__modules.extend(imgcreate.kickstart.get_modules(self.ks))
 
     def _get_disk_type(self):
@@ -229,6 +229,7 @@ def main():
         creator.mount(cachedir=options.cachedir)
         creator.install()
         creator.configure()
+        imgcreate.kickstart.FirewallConfig(creator._instroot).apply(creator.ks.handler.firewall)
         if options.extract_bootfiles:
             creator.extract_bootfiles()
         if options.give_shell:

--- a/ami_creator/ami_creator.py
+++ b/ami_creator/ami_creator.py
@@ -43,6 +43,10 @@ def parse_options(args):
                       help="Name to use for the image")
     imgopt.add_option("-e", "--extract-bootfiles", action="store_true", dest="extract_bootfiles",
                       help="Extract the kernel and ramdisk from the image")
+    imgopt.add_option("-m", "--map-scsi-devices", action="store_true", dest="map_scsi_devices",
+                      help="Create symlinks to xvd* devices from sd* for Xen support")
+    imgopt.add_option("", "--xvd-offset", action="store_true", dest="xvd_offset",
+                      help="Map sd[a-v] to xvd[e-z] (offset by four for EL 6.x)")
     parser.add_option_group(imgopt)
 
     # options related to the config of your system
@@ -71,6 +75,9 @@ def parse_options(args):
     return options
 
 class AmiCreator(imgcreate.LoopImageCreator):
+    map_scsi_devices = False
+    xvd_offset = False
+
     def __init__(self, *args, **kwargs):
         imgcreate.LoopImageCreator.__init__(self, *args, **kwargs)
 
@@ -148,6 +155,8 @@ timeout=%(timeout)s
                                   "disk": self._get_disk_type(),
                                   "bootargs": self._get_kernel_options()}
 
+        if not os.path.exists(self._instroot + "/boot/grub"):
+            os.makedirs(self._instroot + "/boot/grub")
         with open(self._instroot + "/boot/grub/grub.conf", "w") as grubcfg:
             grubcfg.write(cfg)
 
@@ -199,6 +208,68 @@ rootopts="defaults"
         self.__write_mkinitrd_conf(self._instroot + "/etc/sysconfig/mkinitrd/ami.conf")
         # and rhel/centos6 and current fedora (f12+) use dracut anyway
         self.__write_dracut_conf(self._instroot + "/etc/dracut.conf.d/ami.conf")
+        if self.map_scsi_devices:
+            self.__write_udev_config()
+
+    def __write_udev_config(self):
+        if self.map_scsi_devices:
+            with open(self._instroot + "/etc/dracut.conf.d/ami.conf", "a") as f:
+                f.write('add_dracutmodules+=" ami-udev "\n')
+
+        udev_rules = self._instroot + "/etc/udev/rules.d/99-ami-udev.rules"
+        if not os.path.exists(os.path.dirname(udev_rules)):
+            os.makedirs(os.path.dirname(udev_rules))
+        with open(udev_rules, "w") as f:
+            f.write('KERNEL=="xvd*", PROGRAM="/usr/sbin/ami-udev %k", SYMLINK+="%c"\n')
+
+        # We can't know whether this goes in /usr/lib or /usr/share,
+        # so write to both.  Yuck.
+        for x in [ self._instroot + "/usr/lib/dracut/modules.d/99ami-udev",
+                   self._instroot + "/usr/share/dracut/modules.d/99ami-udev" ]:
+            if not os.path.exists(x):
+                os.makedirs(x)
+            modulesetup = x + "/module-setup.sh"
+            with open(modulesetup, "w") as f:
+                f.write('''#!/bin/bash
+install() {
+    inst_rules 99-ami-udev.rules
+    dracut_install /usr/sbin/ami-udev
+}
+''')
+            os.chmod(modulesetup, 0755)
+
+        amiudev = self._instroot + "/usr/sbin/ami-udev"
+        if not os.path.exists(os.path.dirname(amiudev)):
+            os.makedirs(os.path.dirname(amiudev))
+        with open(amiudev, "w") as f:
+            if self.xvd_offset:
+                f.write('''#!/bin/bash
+if [ "$#" -ne 1 ] ; then
+  echo "$0 <device>" >&2
+  exit 1
+else
+  if echo "$1"|grep -qE 'xvd[a-z][0-9]?' ; then
+    letter=`echo "$1" | cut -c 4 | tr [e-z] [a-v]`
+    echo "$1" | sed -e "s/xvd./sd${letter}/"
+  else
+    echo "$1"
+  fi
+fi
+''')
+            else:
+                f.write('''#!/bin/bash
+if [ "$#" -ne 1 ] ; then
+  echo "$0 <device>" >&2
+  exit 1
+else
+  if echo "$1"|grep -qE 'xvd[a-z][0-9]?' ; then
+    echo "$1" | sed -e 's/xvd/sd/'
+  else
+    echo "$1"
+  fi
+fi
+''')
+        os.chmod(amiudev, 0755)
 
     def package(self, destdir="."):
         imgcreate.LoopImageCreator.package(self, destdir)
@@ -224,6 +295,10 @@ def main():
     creator.tmpdir = os.path.abspath(options.tmpdir)
     if options.cachedir:
         options.cachedir = os.path.abspath(options.cachedir)
+    if options.xvd_offset:
+        creator.xvd_offset = True
+    if options.map_scsi_devices:
+        creator.map_scsi_devices = True
 
     try:
         creator.mount(cachedir=options.cachedir)

--- a/ami_creator/ami_creator.py
+++ b/ami_creator/ami_creator.py
@@ -234,9 +234,18 @@ rootopts="defaults"
 install() {
     inst_rules 99-ami-udev.rules
     dracut_install /usr/sbin/ami-udev
+    dracut_install /bin/grep
 }
 ''')
             os.chmod(modulesetup, 0755)
+
+            # EL 6 dracut is different. Just make it source module-setup
+            with open(x + "/install", "w") as f:
+                f.write('''#!/bin/sh
+source $( dirname $BASH_SOURCE )/module-setup.sh
+install
+''')
+            os.chmod(x + "/install", 0755)
 
         amiudev = self._instroot + "/usr/sbin/ami-udev"
         if not os.path.exists(os.path.dirname(amiudev)):
@@ -249,8 +258,7 @@ if [ "$#" -ne 1 ] ; then
   exit 1
 else
   if echo "$1"|grep -qE 'xvd[a-z][0-9]?' ; then
-    letter=`echo "$1" | cut -c 4 | tr [e-z] [a-v]`
-    echo "$1" | sed -e "s/xvd./sd${letter}/"
+    echo sd$( echo ${1:3:1} | sed "y/[e-v]/[a-z]/" )${1:4:2}
   else
     echo "$1"
   fi

--- a/ami_creator/ami_creator.py
+++ b/ami_creator/ami_creator.py
@@ -97,6 +97,8 @@ class AmiCreator(imgcreate.LoopImageCreator):
                     return "xvd"
                 elif part.disk and part.disk.startswith("sd"):
                     return "sd"
+                elif part.disk and part.disk.startswith("vd"):
+                    return "vd"
 
         # otherwise, is this a good criteria?  it works for centos5 vs f14
         if "kernel-xen" in self.ks.handler.packages.packageList:

--- a/ami_creator/ami_creator.py
+++ b/ami_creator/ami_creator.py
@@ -76,8 +76,9 @@ class AmiCreator(imgcreate.LoopImageCreator):
 
         # amis need xenblk at least
         self.__modules = ["xenblk", "xen_blkfront", "virtio_net", "virtio_pci",
-                          "virtio_blk", "virtio_balloon", "e1000", 
-                          "scsi_transport_sas", "mptbase", "mptscsih", "mptsas"]
+                          "virtio_blk", "virtio_balloon", "e1000", "sym53c8xx",
+                          "scsi_transport_sas", "mptbase", "mptscsih",
+                          "sd_mod", "mptsas", "sg" ]
         self.__modules.extend(imgcreate.kickstart.get_modules(self.ks))
 
     def _get_disk_type(self):

--- a/ks-centos6.cfg
+++ b/ks-centos6.cfg
@@ -1,0 +1,95 @@
+# Build a basic CentOS 6 AMI
+lang en_US.UTF-8
+keyboard us
+timezone US/Eastern
+auth --useshadow --enablemd5
+selinux --permissive
+firewall --enabled --ssh
+bootloader --timeout=1 
+network --bootproto=dhcp --device=eth0 --onboot=on
+services --enabled=network
+
+
+# Uncomment the next line
+# to make the root password be password
+# By default the root password is emptied
+#rootpw password
+
+#
+# Define how large you want your rootfs to be
+# NOTE: S3-backed AMIs have a limit of 10G
+#
+part / --size 768 --fstype ext3
+
+#
+# Repositories
+repo --name=CentOS5-Base --mirrorlist=http://mirrorlist.centos.org/?release=6&arch=$basearch&repo=os
+repo --name=CentOS5-Updates --mirrorlist=http://mirrorlist.centos.org/?release=6&arch=$basearch&repo=updates
+repo --name=EPEL --baseurl=http://download.fedora.redhat.com/pub/epel/6/$basearch/
+
+
+#
+#
+# Add all the packages after the base packages
+#
+%packages --nobase --instLangs=en
+@core
+system-config-securitylevel-tui
+system-config-firewall-base
+audit
+pciutils
+bash
+coreutils
+kernel-xen
+grub
+e2fsprogs
+passwd
+policycoreutils
+chkconfig
+rootfiles
+yum
+vim-minimal
+acpid
+openssh-clients
+openssh-server
+curl
+
+#Allow for dhcp access
+dhclient
+iputils
+
+%end
+
+#
+# Add custom post scripts after the base post.
+#
+%post
+%end
+
+# more ec2-ify
+%post --erroronfail
+# disable root password based login
+cat >> /etc/ssh/sshd_config << EOF
+PermitRootLogin without-password
+UseDNS no
+EOF
+
+# set up ssh key fetching
+cat >> /etc/rc.local << EOF
+if [ ! -d /root/.ssh ]; then
+  mkdir -p /root/.ssh
+  chmod 700 /root/.ssh
+fi
+# Fetch public key using HTTP
+KEY_FILE=\$(mktemp)
+curl http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key 2>/dev/null > \$KEY_FILE
+if [ \$? -eq 0 ]; then
+  cat \$KEY_FILE >> /root/.ssh/authorized_keys
+  chmod 600 /root/.ssh/authorized_keys
+fi
+rm -f \$KEY_FILE
+EOF
+sed -i -e 's/^.*-j REJECT.*$//' /etc/sysconfig/iptables
+
+%end
+

--- a/ks-fedora16.cfg
+++ b/ks-fedora16.cfg
@@ -1,0 +1,92 @@
+# Build a basic Fedora 14 AMI
+lang en_US.UTF-8
+keyboard us
+timezone US/Eastern
+auth --useshadow --enablemd5
+selinux --disabled
+firewall --disabled
+bootloader --timeout=1 
+network --bootproto=dhcp --device=eth0 --onboot=on
+services --enabled=network
+
+
+# Uncomment the next line
+# to make the root password be password
+# By default the root password is emptied
+#rootpw password
+
+#
+# Define how large you want your rootfs to be
+# NOTE: S3-backed AMIs have a limit of 10G
+#
+part / --size 1512 --fstype ext3
+
+#
+# Repositories
+repo --name=fedora --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-16&arch=$basearch
+repo --name=updates --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f16&arch=$basearch
+
+#
+#
+# Add all the packages after the base packages
+#
+%packages --excludedocs --nobase --instLangs=en
+@core
+system-config-securitylevel-tui
+audit
+pciutils
+bash
+coreutils
+lokkit
+kernel
+grub2
+e2fsprogs
+passwd
+policycoreutils
+chkconfig
+rootfiles
+yum
+vim-minimal
+acpid
+openssh-clients
+openssh-server
+curl
+
+#Allow for dhcp access
+dhclient
+iputils
+
+%end
+
+#
+# Add custom post scripts after the base post.
+#
+%post
+%end
+
+# more ec2-ify
+%post --erroronfail
+# disable root password based login
+cat >> /etc/ssh/sshd_config << EOF
+PermitRootLogin without-password
+UseDNS no
+EOF
+
+# set up ssh key fetching
+cat >> /etc/rc.local << EOF
+if [ ! -d /root/.ssh ]; then
+  mkdir -p /root/.ssh
+  chmod 700 /root/.ssh
+fi
+# Fetch public key using HTTP
+KEY_FILE=$(mktemp)
+curl http://169.254.169.254/2009-04-04/meta-data/public-keys/0/openssh-key 2>/dev/null > \$KEY_FILE
+if [ \$? -eq 0 ]; then
+  cat \$KEY_FILE >> /root/.ssh/authorized_keys
+  chmod 600 /root/.ssh/authorized_keys
+fi
+rm -f \$KEY_FILE
+EOF
+
+%end
+


### PR DESCRIPTION
- Add an example kickstart for Fedora 16 (should be changed 
  to use cloud-init)
- Add a command line option to extract kernel(s) and ramdisk(s)
- Add more modules to the initrd (this should become distro-aware
  and/or have a related command line option)
- Remove ephemeral device fstab entry, since this prevents
  booting if the ephemeral device is disabled.  This should be
  handled via a command line option or via kickstart.
