### PR TITLE
Update EPEL URL to download.fedoraproject.org

### DIFF
--- a/ks-centos5.cfg
+++ b/ks-centos5.cfg
@@ -26,7 +26,7 @@ part / --size 512 --fstype ext3
 repo --name=CentOS5-Base --mirrorlist=http://mirrorlist.centos.org/?release=5&arch=$basearch&repo=os
 repo --name=CentOS5-Updates --mirrorlist=http://mirrorlist.centos.org/?release=5&arch=$basearch&repo=updates
 repo --name=CentOS5-Addons --mirrorlist=http://mirrorlist.centos.org/?release=5&arch=$basearch&repo=extras
-repo --name=EPEL --baseurl=http://download.fedora.redhat.com/pub/epel/5/$basearch/
+repo --name=EPEL --baseurl=http://download.fedoraproject.org/pub/epel/5/$basearch/
 
 #
 #


### PR DESCRIPTION
The hostname download.fedora.redhat.com was deprecated a couple of years
ago. The CNAME for it was removed earlier this year.

http://lists.fedoraproject.org/pipermail/announce/2012-February/003040.html
