### PR TITLE
Escape command substitutions in %post

### DIFF
--- a/ks-centos5.cfg
+++ b/ks-centos5.cfg
@@ -94,7 +94,7 @@ if [ ! -d /root/.ssh ]; then
   chmod 700 /root/.ssh
 fi
 # Fetch public key using HTTP
-KEY_FILE=$(mktemp)
+KEY_FILE=\$(mktemp)
 curl http://169.254.169.254/2009-04-04/meta-data/public-keys/0/openssh-key 2>/dev/null > \$KEY_FILE
 if [ \$? -eq 0 ]; then
   cat \$KEY_FILE >> /root/.ssh/authorized_keys

--- a/ks-fedora14.cfg
+++ b/ks-fedora14.cfg
@@ -78,7 +78,7 @@ if [ ! -d /root/.ssh ]; then
   chmod 700 /root/.ssh
 fi
 # Fetch public key using HTTP
-KEY_FILE=$(mktemp)
+KEY_FILE=\$(mktemp)
 curl http://169.254.169.254/2009-04-04/meta-data/public-keys/0/openssh-key 2>/dev/null > \$KEY_FILE
 if [ \$? -eq 0 ]; then
   cat \$KEY_FILE >> /root/.ssh/authorized_keys


### PR DESCRIPTION
Not escaping these causes expansion at kickstart time and the directory
names are hardcoded within the built image.
