### PR TITLE
Use FS labels for the root filesystem

### DIFF
--- a/ami_creator/ami_creator.py
+++ b/ami_creator/ami_creator.py
@@ -105,11 +105,12 @@ class AmiCreator(imgcreate.LoopImageCreator):
         return r
 
     def _get_fstab(self):
-        disk = self._get_disk_type()
-        s = "/dev/%sa1  /    %s     defaults   0 0\n" %(disk, self._fstype)
+        s = "LABEL=_/   /        %s      defaults         0 0\n" % self._fstype
+
         # FIXME: should this be the default?
         # Different arch's mnt with different disks.
         # Also, only i386 AMI's have swap set up at a3 suffixed disks
+        disk = self._get_disk_type()
         if rpmUtils.arch.getBaseArch() == 'i386':
             s += "/dev/%sa2  /mnt  ext3   defaults  0 0\n" %(disk,)
             s += "/dev/%sa3  swap  swap   defaults  0 0\n" %(disk,)
@@ -122,7 +123,7 @@ class AmiCreator(imgcreate.LoopImageCreator):
     def _create_bootconfig(self):
         imgtemplate = """title %(title)s %(version)s
         root (hd0)
-        kernel /boot/vmlinuz-%(version)s root=/dev/%(disk)sa1 %(bootargs)s
+        kernel /boot/vmlinuz-%(version)s root=LABEL=_/ %(bootargs)s
         initrd /boot/%(initrdfn)s-%(version)s.img
 """
 
@@ -145,7 +146,6 @@ timeout=%(timeout)s
             cfg += imgtemplate % {"title": self.name,
                                   "version": version,
                                   "initrdfn": initrdfn,
-                                  "disk": self._get_disk_type(),
                                   "bootargs": self._get_kernel_options()}
 
         with open(self._instroot + "/boot/grub/grub.conf", "w") as grubcfg:
@@ -213,7 +213,7 @@ def main():
     if options.name:
         name = options.name
 
-    creator = AmiCreator(ks, name)
+    creator = AmiCreator(ks, name, "/")
     creator.tmpdir = os.path.abspath(options.tmpdir)
     if options.cachedir:
         options.cachedir = os.path.abspath(options.cachedir)


### PR DESCRIPTION
Becomes agnostic to block device maps on different kernels.
Ephemeral stores need to be tackled separately.

---

Tested on CentOS 5.8 and 6.2
